### PR TITLE
feat: 근처 약국 지도 기능 고도화 및 상담 메모 영어화 개선

### DIFF
--- a/skn22_4th_prj/chat/urls.py
+++ b/skn22_4th_prj/chat/urls.py
@@ -6,6 +6,7 @@ app_name = "chat"
 urlpatterns = [
     path("", views.home, name="home"),
     path("smart-search/", views.smart_search, name="smart_search"),
+    path("smart-search-products/", views.symptom_products_page, name="symptom_products_page"),
     path("api/pharmacies/", views.pharmacy_api, name="pharmacy_api"),
     path("api/symptom-products/", views.symptom_products_api, name="symptom_products_api"),
 ]

--- a/skn22_4th_prj/chat/views.py
+++ b/skn22_4th_prj/chat/views.py
@@ -1,11 +1,12 @@
-import os
+﻿import os
 import logging
 import asyncio
 import json
+import re
 from collections import Counter
 from functools import lru_cache
 
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse, JsonResponse
 
 from graph_agent.builder_v2 import build_graph
@@ -50,13 +51,13 @@ def _guidance_by_dur_type(dur_type):
     is_caution = ("caution" in t_lower) or ("주의" in t)
 
     if is_combined and is_contra:
-        return "다른 성분과의 병용이 제한된다고 안내되고 있습니다."
+        return "다른 성분과의 병용이 금지되는 항목으로 안내되고 있습니다."
     if is_combined and is_caution:
         return "다른 성분과 병용 시 이상반응 가능성이 있다고 안내되고 있습니다."
     if "pregnan" in t_lower or "임부" in t or "임신" in t:
-        return "임신 중 사용 제한 또는 주의가 필요하다고 안내되고 있습니다."
+        return "임신 중 사용 금지 또는 주의가 필요한 항목으로 안내되고 있습니다."
     if "elder" in t_lower or "geriatric" in t_lower or "노인" in t or "고령" in t:
-        return "고령자에서 주의가 필요하다고 안내되고 있습니다."
+        return "고령자에서 주의가 필요한 항목으로 안내되고 있습니다."
     if (
         "adolescent" in t_lower
         or "pediatric" in t_lower
@@ -65,11 +66,11 @@ def _guidance_by_dur_type(dur_type):
         or "청소년" in t
         or "소아" in t
     ):
-        return "연령 기준에 따른 사용 제한 또는 주의가 필요하다고 안내되고 있습니다."
+        return "연령 기준에 따른 사용 제한 또는 주의가 필요한 항목으로 안내되고 있습니다."
     if "dose" in t_lower or "용량" in t:
-        return "권장 용량 범위를 준수해야 한다고 안내되고 있습니다."
+        return "권장 용량 범위를 준수해야 하는 항목으로 안내되고 있습니다."
     if "duration" in t_lower or "기간" in t:
-        return "권장 투여 기간을 넘기지 않도록 안내되고 있습니다."
+        return "권장 투여 기간을 초과하지 않도록 안내되고 있습니다."
     if (
         "disease" in t_lower
         or "condition" in t_lower
@@ -79,12 +80,12 @@ def _guidance_by_dur_type(dur_type):
         or "신장" in t
         or "간" in t
     ):
-        return "기저 질환 여부에 따른 사용 주의가 필요하다고 안내되고 있습니다."
+        return "기저 질환 여부에 따라 사용 주의가 필요한 항목으로 안내되고 있습니다."
     if is_contra:
-        return "금기 항목으로 안내되고 있어 전문가 확인이 권고됩니다."
+        return "금기 항목으로 안내되고 있어 전문가 확인을 권고합니다."
     if is_caution:
-        return "주의 항목으로 안내되고 있어 전문가 확인이 권고됩니다."
-    return "개인 상태에 따라 적용 기준이 달라질 수 있다고 안내되고 있습니다."
+        return "주의 항목으로 안내되고 있어 전문가 확인을 권고합니다."
+    return "개인 상태에 따라 적용 기준이 달라질 수 있는 항목입니다."
 
 
 def _build_dur_summary(dur_entries, limit=5):
@@ -108,8 +109,8 @@ def _build_dur_summary(dur_entries, limit=5):
         ingredient = entry["ingredient"] or "해당 성분"
         guidance = _guidance_by_dur_type(entry["type"])
         line = (
-            f"{ingredient}: DUR 기준상 '{entry['type']}' 항목으로 안내되고 있습니다. "
-            f"{guidance} 세부 적용 여부는 의사 또는 약사 상담을 통해 확인이 권고됩니다."
+            f"{ingredient}: DUR 기준 '{entry['type']}' 항목으로 안내되고 있습니다. "
+            f"{guidance} 실제 적용 여부는 의사 또는 약사 상담을 통해 확인하시길 권고합니다."
         )
         if entry["warning"]:
             warning = entry["warning"]
@@ -127,15 +128,192 @@ def _build_dur_summary(dur_entries, limit=5):
     }
 
 
+_EMPTY_PROFILE_TOKENS = {"", "none", "없음", "없어요", "n/a", "na", "x"}
+_SYMPTOM_KR_TO_EN = {
+    "두통": "headache",
+    "편두통": "migraine",
+    "알레르기": "allergy",
+    "기침": "cough",
+    "감기": "common cold",
+    "발열": "fever",
+    "소화불량": "indigestion",
+    "복통": "abdominal pain",
+    "통증": "pain",
+    "염좌": "sprain",
+    "찰과상": "abrasion",
+    "상처": "wound",
+    "화상": "burn",
+    "곤충교상": "insect bite",
+}
+
+
+def _to_profile_display(value: str, fallback: str = "Not provided") -> str:
+    token = str(value or "").strip()
+    if not token:
+        return fallback
+    if token.lower() in _EMPTY_PROFILE_TOKENS:
+        return fallback
+    return token
+
+
+def _to_english_symptom(symptom: str, symptom_term: str = "", symptom_keyword: str = "") -> str:
+    candidates = [symptom_term, symptom_keyword, symptom]
+
+    for raw in candidates:
+        token = str(raw or "").strip()
+        if not token:
+            continue
+
+        # Already English/plain text.
+        if re.search(r"[A-Za-z]", token) and not re.search(r"[가-힣]", token):
+            return token
+
+        # Exact mapping.
+        if token in _SYMPTOM_KR_TO_EN:
+            return _SYMPTOM_KR_TO_EN[token]
+
+        # Phrase contains known Korean symptom term.
+        for kr_term, en_term in _SYMPTOM_KR_TO_EN.items():
+            if kr_term in token:
+                return en_term
+
+    return "unspecified symptom"
+
+
+def _contains_hangul(text: str) -> bool:
+    return bool(re.search(r"[가-힣]", str(text or "")))
+
+
+async def _translate_profile_fields_to_english(meds: str, allergies: str, diseases: str):
+    values = {
+        "meds": str(meds or "").strip(),
+        "allergies": str(allergies or "").strip(),
+        "diseases": str(diseases or "").strip(),
+    }
+    translatable = {
+        key: value
+        for key, value in values.items()
+        if value and value != "Not provided" and _contains_hangul(value)
+    }
+    if not translatable:
+        return values
+
+    try:
+        from services.ai_service_v2 import AIService
+
+        client = AIService.get_client()
+        if not client:
+            return values
+
+        prompt = (
+            "Translate the following user medical profile fields into clear English.\n"
+            "Rules:\n"
+            "- Preserve medicine names, strengths, bracketed codes, and parentheses.\n"
+            "- Keep factual content intact.\n"
+            "- If a field is already in English, keep it as-is.\n"
+            "Return ONLY JSON with keys: meds, allergies, diseases."
+        )
+        res = await client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a medical translator."},
+                {
+                    "role": "user",
+                    "content": f"{prompt}\n\n{json.dumps(values, ensure_ascii=False)}",
+                },
+            ],
+            temperature=0,
+            response_format={"type": "json_object"},
+        )
+        payload = json.loads(res.choices[0].message.content or "{}")
+        if isinstance(payload, dict):
+            for key in ("meds", "allergies", "diseases"):
+                translated = str(payload.get(key) or "").strip()
+                if translated:
+                    values[key] = translated
+    except Exception as e:
+        logger.warning(f"profile field translation failed: {e}")
+
+    return values
+
+
+async def _build_consultation_note(
+    symptom: str,
+    user_profile: dict,
+    symptom_term: str = "",
+    symptom_keyword: str = "",
+):
+    profile = user_profile if isinstance(user_profile, dict) else {}
+    meds = _to_profile_display(profile.get("current_medications"))
+    allergies = _to_profile_display(profile.get("allergies"))
+    diseases = _to_profile_display(profile.get("chronic_diseases"))
+    translated = await _translate_profile_fields_to_english(meds, allergies, diseases)
+    meds = translated["meds"]
+    allergies = translated["allergies"]
+    diseases = translated["diseases"]
+    pregnancy = "Yes" if bool(profile.get("is_pregnant")) else "No"
+    symptom_text = _to_english_symptom(
+        symptom=symptom,
+        symptom_term=symptom_term,
+        symptom_keyword=symptom_keyword,
+    )
+
+    memo_text = (
+        f"Hello, I would like consultation for the symptom '{symptom_text}'.\n"
+        f"- Current medications: {meds}\n"
+        f"- Allergies: {allergies}\n"
+        f"- Chronic conditions: {diseases}\n"
+        f"- Pregnancy/Breastfeeding: {pregnancy}\n\n"
+        "Please advise which OTC options are appropriate, which ingredients to avoid,\n"
+        "and confirm dose, duration, and interaction risks."
+    )
+
+    return {
+        "symptom": symptom_text,
+        "meds": meds,
+        "allergies": allergies,
+        "diseases": diseases,
+        "pregnancy": pregnancy,
+        "memo_text": memo_text,
+    }
+
 def home(request):
     user = request.session.get("supabase_user")
-    return render(request, "index.html", {"user": user})
+    return render(
+        request,
+        "index.html",
+        {
+            "user": user,
+            "maps_key": os.getenv("GOOGLE_MAPS_API_KEY"),
+        },
+    )
+
+
+def symptom_products_page(request):
+    payload = request.session.get("last_symptom_result")
+    if not isinstance(payload, dict):
+        return redirect("chat:home")
+
+    symptom = str(payload.get("symptom") or "").strip()
+    ingredients_data = payload.get("ingredients_data", [])
+    if not isinstance(ingredients_data, list):
+        ingredients_data = []
+
+    return render(
+        request,
+        "symptom_products_page.html",
+        {
+            "symptom": symptom,
+            "answer": payload.get("answer", ""),
+            "ingredients_data": ingredients_data,
+        },
+    )
 
 
 async def smart_search(request):
     query = request.GET.get("q") or request.POST.get("q")
     if not query:
-        return HttpResponse("<script>alert('검색어를 입력하세요.'); history.back();</script>")
+        return HttpResponse("<script>alert('寃?됱뼱瑜??낅젰?섏꽭??); history.back();</script>")
 
     logger.info(f"LangGraph User Query: {query}")
 
@@ -146,23 +324,38 @@ async def smart_search(request):
         result = await get_graph().ainvoke(inputs)
     except Exception as e:
         logger.error(f"Graph Execution Error: {e}")
-        return render(request, "error.html", {"message": f"처리 중 오류가 발생했습니다: {str(e)}"})
+        return render(request, "error.html", {"message": f"泥섎━ 以??ㅻ쪟媛 諛쒖깮?덉뒿?덈떎: {str(e)}"})
 
     category = result.get("category")
     final_answer = result.get("final_answer", "")
 
     if category == "symptom_recommendation":
         dur_data = result.get("dur_data", [])
+        ingredients_data = result.get("ingredients_data", [])
+        consultation_note = await _build_consultation_note(
+            symptom=query,
+            user_profile=result.get("user_profile") or {},
+            symptom_term=result.get("symptom_term") or "",
+            symptom_keyword=result.get("keyword") or "",
+        )
+        request.session["last_symptom_result"] = {
+            "symptom": query,
+            "answer": final_answer,
+            "ingredients_data": ingredients_data,
+            "dur_details": dur_data,
+            "consultation_note": consultation_note,
+        }
         return render(
             request,
             "symptom_result.html",
             {
                 "symptom": query,
                 "answer": final_answer,
-                "ingredients_data": result.get("ingredients_data", []),
+                "ingredients_data": ingredients_data,
                 "dur_details": dur_data,
                 "dur_summary": _build_dur_summary(dur_data),
                 "maps_key": os.getenv("GOOGLE_MAPS_API_KEY"),
+                "consultation_note": consultation_note,
             },
         )
 
@@ -174,7 +367,7 @@ async def smart_search(request):
             return render(
                 request,
                 "error.html",
-                {"message": final_answer or f"'{query}' 관련 정보를 찾을 수 없습니다."},
+                {"message": final_answer or f"'{query}' 愿???뺣낫瑜?李얠쓣 ???놁뒿?덈떎."},
             )
 
         return render(
@@ -192,6 +385,12 @@ async def smart_search(request):
         )
 
     if category == "general_medical":
+        consultation_note = await _build_consultation_note(
+            symptom=query,
+            user_profile=result.get("user_profile") or {},
+            symptom_term=result.get("symptom_term") or "",
+            symptom_keyword=result.get("keyword") or "",
+        )
         return render(
             request,
             "symptom_result.html",
@@ -201,24 +400,44 @@ async def smart_search(request):
                 "dur_details": [],
                 "dur_summary": _build_dur_summary([]),
                 "maps_key": os.getenv("GOOGLE_MAPS_API_KEY"),
+                "consultation_note": consultation_note,
             },
         )
 
     return render(
         request,
         "error.html",
-        {"message": final_answer or "요청을 처리할 수 없습니다."},
+        {"message": final_answer or "?붿껌??泥섎━?????놁뒿?덈떎."},
     )
 
 
 async def pharmacy_api(request):
-    lat = float(request.GET.get("lat", 0))
-    lng = float(request.GET.get("lng", 0))
+    try:
+        lat = float(request.GET.get("lat", 0))
+        lng = float(request.GET.get("lng", 0))
+        radius_m = int(request.GET.get("radius", 3000) or 3000)
+        limit = int(request.GET.get("limit", 10) or 10)
+    except (TypeError, ValueError):
+        return JsonResponse(
+            {"status": "error", "message": "Invalid coordinates or query params"},
+            status=400,
+        )
+
+    if not (-90 <= lat <= 90 and -180 <= lng <= 180):
+        return JsonResponse(
+            {"status": "error", "message": "Coordinates out of range"},
+            status=400,
+        )
 
     from services.map_service import MapService
 
     try:
-        results = await MapService.find_nearby_pharmacies(lat, lng)
+        results = await MapService.find_nearby_pharmacies(
+            lat=lat,
+            lng=lng,
+            radius_m=radius_m,
+            limit=limit,
+        )
         return JsonResponse({"status": "success", "results": results})
     except Exception as e:
         logger.error(f"Error fetching pharmacies: {e}")
@@ -249,6 +468,105 @@ async def symptom_products_api(request):
     candidate_fetch_limit = 10
     max_extra_component_lookups = 24
     max_excluded_reason_items = 4
+    from services.user_service import UserService
+    from services.ingredient_utils import canonicalize_ingredient_name
+
+    def _is_combined_contra_text(text: str) -> bool:
+        token = str(text or "").strip().lower()
+        if not token:
+            return False
+        return (
+            "병용금기" in token
+            or "contraindicated combination" in token
+            or ("contra" in token and "combined" in token)
+        )
+
+    def _is_pregnancy_text(text: str) -> bool:
+        token = str(text or "").strip().lower()
+        if not token:
+            return False
+        return (
+            "임부" in token
+            or "임신" in token
+            or "수유" in token
+            or "pregnan" in token
+            or "lactat" in token
+            or "breastfeeding" in token
+        )
+
+    def _extract_combined_partner_tokens(warning_text: str) -> list:
+        raw = str(warning_text or "")
+        if not raw:
+            return []
+
+        patterns = [
+            r"병용금기\s*성분\s*:\s*([^\n]+)",
+            r"contraindicated\s*(?:with)?\s*:\s*([^\n]+)",
+        ]
+        captured = ""
+        for pattern in patterns:
+            matched = re.search(pattern, raw, flags=re.IGNORECASE)
+            if matched:
+                captured = str(matched.group(1) or "").strip()
+                break
+        if not captured:
+            return []
+
+        chunks = re.split(r"[,/;|+]", captured)
+        tokens = []
+        seen = set()
+        for chunk in chunks:
+            token = str(chunk or "").strip().upper()
+            token = re.sub(r"\([^)]*\)", "", token).strip()
+            if not token:
+                continue
+            token = canonicalize_ingredient_name(token)
+            token = str(token or "").strip().upper()
+            if len(token) < 2 or token in seen:
+                continue
+            seen.add(token)
+            tokens.append(token)
+        return tokens
+
+    def _build_user_med_ingredient_set(profile: dict) -> set:
+        sources = [
+            str((profile or {}).get("main_ingr_eng") or "").strip(),
+            str((profile or {}).get("current_medications") or "").strip(),
+        ]
+        token_set = set()
+        for source in sources:
+            if not source:
+                continue
+            pieces = re.split(r"[,/;|\n+]+", source)
+            for piece in pieces:
+                token = str(piece or "").strip().upper()
+                token = re.sub(r"\([^)]*\)", "", token).strip()
+                if not token:
+                    continue
+                token = canonicalize_ingredient_name(token)
+                token = str(token or "").strip().upper()
+                if len(token) >= 2:
+                    token_set.add(token)
+        return token_set
+
+    user_profile = {}
+    user_med_ingredients = set()
+    user_is_pregnant = False
+    try:
+        user_info = request.session.get("supabase_user")
+        if isinstance(user_info, dict) and user_info.get("id"):
+            profile = await UserService.get_profile(user_info)
+            user_profile = {
+                "current_medications": str(
+                    getattr(profile, "current_medications", "") or ""
+                ).strip(),
+                "main_ingr_eng": str(getattr(profile, "main_ingr_eng", "") or "").strip(),
+                "is_pregnant": bool(getattr(profile, "is_pregnant", False)),
+            }
+            user_med_ingredients = _build_user_med_ingredient_set(user_profile)
+            user_is_pregnant = bool(user_profile.get("is_pregnant"))
+    except Exception as e:
+        logger.warning(f"failed to load user profile in symptom_products_api: {e}")
 
     async def fetch_one(ingr):
         async with semaphore:
@@ -322,28 +640,56 @@ async def symptom_products_api(request):
                 )
                 if not name or not kr_durs:
                     continue
-
-                risk_types = []
+                all_types = []
+                hard_block_types = []
                 risk_summary = ""
+                matched_partners = []
                 for dur in kr_durs:
                     if not isinstance(dur, dict):
                         continue
                     dur_type = str(dur.get("type") or "").strip()
+                    warning_text = str(dur.get("warning") or "").strip()
                     if dur_type:
-                        risk_types.append(dur_type)
+                        all_types.append(dur_type)
                     if not risk_summary:
-                        risk_summary = str(dur.get("warning") or "").strip()
+                        risk_summary = warning_text
 
-                risk_types = sorted(set([x for x in risk_types if x]))
+                    merged_text = f"{dur_type} {warning_text}"
+
+                    if _is_pregnancy_text(merged_text):
+                        if user_is_pregnant:
+                            hard_block_types.append(dur_type or "임부금기")
+                            if warning_text:
+                                risk_summary = warning_text
+                        continue
+
+                    if _is_combined_contra_text(merged_text):
+                        if user_med_ingredients:
+                            partner_tokens = _extract_combined_partner_tokens(warning_text)
+                            matched = [p for p in partner_tokens if p in user_med_ingredients]
+                            if matched:
+                                hard_block_types.append(dur_type or "병용금기")
+                                matched_partners.extend(matched[:3])
+                                risk_summary = (
+                                    f"현재 복용 성분과 병용금기 성분이 일치합니다: "
+                                    f"{', '.join(matched[:3])}"
+                                )
+                        # If current meds are empty or no direct match, do not hard-block.
+                        continue
+
+                all_types = sorted(set([x for x in all_types if x]))
+                hard_block_types = sorted(set([x for x in hard_block_types if x]))
+                matched_partners = sorted(set([x for x in matched_partners if x]))
                 if len(risk_summary) > 140:
                     risk_summary = risk_summary[:137].rstrip() + "..."
 
                 extra_dur_map[name] = {
-                    "has_dur_risk": True,
-                    "dur_risk_types": risk_types[:3],
+                    "has_dur_risk": bool(hard_block_types),
+                    "dur_risk_types": hard_block_types[:3] if hard_block_types else all_types[:3],
                     "dur_risk_summary": risk_summary,
+                    "dur_all_types": all_types[:5],
+                    "matched_partners": matched_partners[:3],
                 }
-
         for payload in payload_items or []:
             products = (
                 payload.get("products")
@@ -369,11 +715,16 @@ async def symptom_products_api(request):
                     meta = extra_dur_map.get(comp_name, {})
                     has_risk = bool(meta.get("has_dur_risk"))
                     if has_risk:
+                        risk_types = list(meta.get("dur_risk_types", []))
+                        matched = [x for x in (meta.get("matched_partners") or []) if x]
+                        if matched:
+                            risk_types.append(f"복용약매칭:{', '.join(matched[:3])}")
                         risk_components.append(
                             {
                                 "name": comp_name,
-                                "types": meta.get("dur_risk_types", []),
+                                "types": risk_types,
                                 "summary": meta.get("dur_risk_summary", ""),
+                                "matched_partners": meta.get("matched_partners", []),
                             }
                         )
 
@@ -393,7 +744,7 @@ async def symptom_products_api(request):
                     preview_names = ", ".join([c["name"] for c in risk_components[:3]])
                     product["has_other_active_dur_risk"] = True
                     product["other_active_dur_notice"] = (
-                        f"추가 주성분 DUR 위험으로 제외: {preview_names}"
+                        f"추가 주성분 금기(DUR) 성분으로 제외: {preview_names}"
                     )
                     excluded_products.append(
                         {
@@ -416,12 +767,12 @@ async def symptom_products_api(request):
             if excluded_products:
                 if payload["products"]:
                     payload["other_component_dur_notice"] = (
-                        f"추가 주성분 DUR 위험 제품 {len(excluded_products)}개를 제외하고 "
-                        f"복용 가능 후보 {len(payload['products'])}개를 추천합니다."
+                        f"추가 주성분 금기(DUR) 제품 {len(excluded_products)}개를 제외하고 "
+                        f"복용 가능한 후보 {len(payload['products'])}개를 추천합니다."
                     )
                 else:
                     payload["other_component_dur_notice"] = (
-                        "후보 제품이 추가 주성분 DUR 위험으로 제외되었습니다."
+                        "후보 제품이 추가 주성분 금기(DUR)로 제외되었습니다."
                     )
 
             diagnostics = payload.get("diagnostics")
@@ -502,3 +853,7 @@ async def symptom_products_api(request):
             for item in items
         ]
     return JsonResponse(response_payload)
+
+
+
+

--- a/skn22_4th_prj/graph_agent/nodes_v2.py
+++ b/skn22_4th_prj/graph_agent/nodes_v2.py
@@ -697,9 +697,12 @@ async def generate_symptom_answer_node(state: AgentState) -> AgentState:
         else:
             safe_ingredients.append(entry)
 
-    # UX priority: show actionable (can_take=true) ingredients/products first,
-    # then show blocked ingredients as additional safety information.
-    ingredients_data = safe_ingredients + blocked_ingredients
+    # UX priority:
+    # - Keep up to 10 actionable ingredients as product-page candidates.
+    # - The product page displays up to 5 cards and backfills from this candidate pool.
+    # - Keep blocked ingredients for safety explanation.
+    max_safe_candidates = 10
+    ingredients_data = safe_ingredients[:max_safe_candidates] + blocked_ingredients
 
     profile_tail = _build_profile_reflection_tail(state.get("user_profile"), ingredients_data)
     final_answer = summary + profile_tail if profile_tail else summary

--- a/skn22_4th_prj/services/map_service.py
+++ b/skn22_4th_prj/services/map_service.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import math
+import os
 import re
 from urllib.parse import quote_plus
 
@@ -15,6 +17,9 @@ logger = logging.getLogger(__name__)
 class MapService:
     _FDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
     _FDA_NDC_URL = "https://api.fda.gov/drug/ndc.json"
+    _GOOGLE_PLACES_NEARBY_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json"
+    _GOOGLE_PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
+    _OSM_OVERPASS_URL = "https://overpass-api.de/api/interpreter"
     _OTC_FILTER = 'openfda.product_type:"HUMAN OTC DRUG"'
     _NDC_MARKETING_CACHE = {}
     _NDC_LOOKUP_SEMAPHORE = asyncio.Semaphore(6)
@@ -65,10 +70,284 @@ class MapService:
         ("diarrhea", "설사 증상 완화"),
         ("sleep", "수면 보조"),
     ]
+    _VET_TOKEN_PATTERN = re.compile(
+        r"\b(vet|veterinary|animal|pet|pets)\b",
+        flags=re.IGNORECASE,
+    )
+    _VET_KR_KEYWORDS = ("동물", "반려", "애완", "수의")
 
     @classmethod
-    async def find_nearby_pharmacies(cls, lat: float, lng: float):
-        return []
+    async def find_nearby_pharmacies(
+        cls, lat: float, lng: float, radius_m: int = 3000, limit: int = 10
+    ):
+        try:
+            lat_v = float(lat)
+            lng_v = float(lng)
+        except Exception:
+            return []
+
+        if not (-90 <= lat_v <= 90 and -180 <= lng_v <= 180):
+            return []
+        radius_v = int(max(500, min(int(radius_m or 3000), 10000)))
+        limit_v = int(max(1, min(int(limit or 10), 30)))
+
+        google_key = str(os.getenv("GOOGLE_MAPS_API_KEY") or "").strip()
+        google_results = []
+        if google_key:
+            try:
+                google_results = await cls._find_nearby_pharmacies_google(
+                    lat=lat_v,
+                    lng=lng_v,
+                    api_key=google_key,
+                    radius_m=radius_v,
+                    limit=limit_v,
+                )
+            except Exception as e:
+                logger.warning(f"Google nearby pharmacy lookup failed: {e}")
+                google_results = []
+        if google_results:
+            return google_results
+
+        try:
+            return await cls._find_nearby_pharmacies_osm(
+                lat=lat_v,
+                lng=lng_v,
+                radius_m=radius_v,
+                limit=limit_v,
+            )
+        except Exception as e:
+            logger.warning(f"OSM nearby pharmacy lookup failed: {e}")
+            return []
+
+    @staticmethod
+    def _distance_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+        r = 6371000.0
+        p1 = math.radians(lat1)
+        p2 = math.radians(lat2)
+        dp = math.radians(lat2 - lat1)
+        dl = math.radians(lng2 - lng1)
+        a = (math.sin(dp / 2) ** 2) + math.cos(p1) * math.cos(p2) * (math.sin(dl / 2) ** 2)
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+        return r * c
+
+    @classmethod
+    def _is_veterinary_or_pet_place(
+        cls,
+        name: str = "",
+        address: str = "",
+        extra_tokens=None,
+        extra_text: str = "",
+    ) -> bool:
+        token_values = []
+        for value in extra_tokens or []:
+            text = str(value or "").strip()
+            if text:
+                token_values.append(text)
+
+        merged = " ".join(
+            [str(name or "").strip(), str(address or "").strip(), str(extra_text or "").strip(), " ".join(token_values)]
+        ).strip()
+        if not merged:
+            return False
+
+        lowered = merged.lower()
+        if cls._VET_TOKEN_PATTERN.search(lowered):
+            return True
+        if any(keyword in merged for keyword in cls._VET_KR_KEYWORDS):
+            return True
+
+        token_set = {x.lower() for x in token_values}
+        if {"veterinary", "veterinary_care", "animal_hospital", "pet_store"}.intersection(token_set):
+            return True
+        return False
+
+    @classmethod
+    async def _find_nearby_pharmacies_google(
+        cls, lat: float, lng: float, api_key: str, radius_m: int = 3000, limit: int = 10
+    ) -> list:
+        params = {
+            "location": f"{lat},{lng}",
+            "radius": int(max(radius_m, 500)),
+            "type": "pharmacy",
+            "language": "en",
+            "key": api_key,
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            res = await client.get(cls._GOOGLE_PLACES_NEARBY_URL, params=params)
+            if res.status_code != 200:
+                raise RuntimeError(f"google_places_http_{res.status_code}")
+            payload = res.json()
+            status = str(payload.get("status") or "")
+            if status not in {"OK", "ZERO_RESULTS"}:
+                message = str(payload.get("error_message") or status or "unknown_error")
+                raise RuntimeError(message)
+
+            raw = payload.get("results") or []
+            items = []
+            for row in raw:
+                if not isinstance(row, dict):
+                    continue
+                geo = (row.get("geometry") or {}).get("location") or {}
+                item_lat = geo.get("lat")
+                item_lng = geo.get("lng")
+                if item_lat is None or item_lng is None:
+                    continue
+                name = str(row.get("name") or "Pharmacy").strip()
+                address = str(row.get("vicinity") or row.get("formatted_address") or "").strip()
+                types = row.get("types") or []
+                if cls._is_veterinary_or_pet_place(
+                    name=name,
+                    address=address,
+                    extra_tokens=types,
+                ):
+                    continue
+
+                items.append(
+                    {
+                        "name": name or "Pharmacy",
+                        "address": address,
+                        "vicinity": row.get("vicinity") or "",
+                        "formatted_address": row.get("formatted_address") or row.get("vicinity") or "",
+                        "lat": item_lat,
+                        "lng": item_lng,
+                        "place_id": row.get("place_id") or "",
+                        "phone": "",
+                        "open_now": (row.get("opening_hours") or {}).get("open_now"),
+                        "opening_hours_text": "",
+                        "rating": row.get("rating"),
+                        "user_ratings_total": row.get("user_ratings_total"),
+                        "source": "google_places",
+                    }
+                )
+
+            trimmed = items[: max(limit, 1)]
+            semaphore = asyncio.Semaphore(5)
+
+            async def _enrich(item: dict):
+                place_id = str(item.get("place_id") or "").strip()
+                if not place_id:
+                    return
+                async with semaphore:
+                    details = await cls._fetch_google_place_details(client, place_id, api_key)
+                if not isinstance(details, dict):
+                    return
+                if details.get("phone"):
+                    item["phone"] = details.get("phone")
+                if details.get("opening_hours_text"):
+                    item["opening_hours_text"] = details.get("opening_hours_text")
+                if isinstance(details.get("open_now"), bool):
+                    item["open_now"] = details.get("open_now")
+
+            await asyncio.gather(*[_enrich(item) for item in trimmed])
+            return trimmed
+
+    @classmethod
+    async def _fetch_google_place_details(
+        cls, client: httpx.AsyncClient, place_id: str, api_key: str
+    ) -> dict:
+        if not place_id or not api_key:
+            return {}
+        params = {
+            "place_id": place_id,
+            "fields": "opening_hours,formatted_phone_number",
+            "language": "en",
+            "key": api_key,
+        }
+        try:
+            res = await client.get(cls._GOOGLE_PLACE_DETAILS_URL, params=params)
+            if res.status_code != 200:
+                return {}
+            payload = res.json()
+            status = str(payload.get("status") or "")
+            if status not in {"OK", "ZERO_RESULTS"}:
+                return {}
+            result = payload.get("result") or {}
+            opening = result.get("opening_hours") or {}
+            weekday_text = opening.get("weekday_text") or []
+            opening_hours_text = " / ".join(
+                [str(x).strip() for x in weekday_text if str(x).strip()]
+            )
+            open_now = opening.get("open_now")
+            phone = str(result.get("formatted_phone_number") or "").strip()
+            return {
+                "phone": phone,
+                "open_now": bool(open_now) if isinstance(open_now, bool) else None,
+                "opening_hours_text": opening_hours_text,
+            }
+        except Exception as e:
+            logger.debug(f"Google place details lookup failed for {place_id}: {e}")
+            return {}
+
+    @classmethod
+    async def _find_nearby_pharmacies_osm(
+        cls, lat: float, lng: float, radius_m: int = 3000, limit: int = 10
+    ) -> list:
+        radius = int(max(radius_m, 500))
+        query = (
+            "[out:json][timeout:20];"
+            "("
+            f'node["amenity"="pharmacy"](around:{radius},{lat},{lng});'
+            f'way["amenity"="pharmacy"](around:{radius},{lat},{lng});'
+            f'relation["amenity"="pharmacy"](around:{radius},{lat},{lng});'
+            ");"
+            "out center tags;"
+        )
+
+        async with httpx.AsyncClient(timeout=12.0) as client:
+            res = await client.post(cls._OSM_OVERPASS_URL, data={"data": query})
+            if res.status_code != 200:
+                raise RuntimeError(f"osm_overpass_http_{res.status_code}")
+            payload = res.json()
+
+        elements = payload.get("elements") or []
+        parsed = []
+        for row in elements:
+            if not isinstance(row, dict):
+                continue
+
+            center = row.get("center") or {}
+            item_lat = row.get("lat", center.get("lat"))
+            item_lng = row.get("lon", center.get("lon"))
+            if item_lat is None or item_lng is None:
+                continue
+
+            tags = row.get("tags") or {}
+            name = str(tags.get("name") or tags.get("brand") or "Pharmacy").strip()
+            if not name:
+                name = "Pharmacy"
+
+            house = str(tags.get("addr:housenumber") or "").strip()
+            street = str(tags.get("addr:street") or "").strip()
+            city = str(tags.get("addr:city") or tags.get("addr:town") or tags.get("addr:village") or "").strip()
+            postcode = str(tags.get("addr:postcode") or "").strip()
+            address_parts = [x for x in [house, street, city, postcode] if x]
+            address = ", ".join(address_parts)
+            if cls._is_veterinary_or_pet_place(
+                name=name,
+                address=address,
+                extra_tokens=[tags.get("healthcare"), tags.get("amenity"), tags.get("shop")],
+                extra_text=f"{tags.get('operator') or ''} {tags.get('description') or ''}",
+            ):
+                continue
+
+            parsed.append(
+                {
+                    "name": name,
+                    "address": address,
+                    "vicinity": address,
+                    "formatted_address": address,
+                    "lat": item_lat,
+                    "lng": item_lng,
+                    "phone": str(tags.get("phone") or tags.get("contact:phone") or "").strip(),
+                    "opening_hours_text": str(tags.get("opening_hours") or "").strip(),
+                    "distance_m": round(cls._distance_meters(lat, lng, float(item_lat), float(item_lng))),
+                    "source": "osm_overpass",
+                }
+            )
+
+        parsed.sort(key=lambda x: x.get("distance_m", 10**9))
+        return parsed[: max(limit, 1)]
 
     @classmethod
     def _normalize_ingredient(cls, raw_value: str) -> str:
@@ -473,7 +752,7 @@ class MapService:
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             try:
-                primary_url = f"{cls._FDA_LABEL_URL}?search={primary_query}&limit=100"
+                primary_url = f"{cls._FDA_LABEL_URL}?search={primary_query}&limit=50"
                 response = await client.get(primary_url)
                 if response.status_code != 200:
                     data = []
@@ -484,7 +763,7 @@ class MapService:
                 # Fallback for ingredients whose OTC labels are indexed under active_ingredient text.
                 if not data:
                     diagnostics["fallback_used"] = True
-                    fallback_url = f"{cls._FDA_LABEL_URL}?search={fallback_query}&limit=100"
+                    fallback_url = f"{cls._FDA_LABEL_URL}?search={fallback_query}&limit=50"
                     fallback_res = await client.get(fallback_url)
                     if fallback_res.status_code == 200:
                         data = fallback_res.json().get("results", [])

--- a/skn22_4th_prj/templates/index.html
+++ b/skn22_4th_prj/templates/index.html
@@ -11,6 +11,10 @@
       href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
 
     <style>
       :root {
@@ -298,6 +302,131 @@
         margin-bottom: 2rem;
       }
 
+      .pharmacy-finder {
+        margin-bottom: 2rem;
+        padding: 1.2rem;
+      }
+
+      .pharmacy-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.7rem;
+        flex-wrap: wrap;
+      }
+
+      .pharmacy-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        flex-wrap: wrap;
+      }
+
+      .pharmacy-head h3 {
+        font-size: 1rem;
+        letter-spacing: -0.01em;
+      }
+
+      .pharmacy-head p {
+        color: var(--ink-700);
+        font-size: 0.86rem;
+      }
+
+      .pharmacy-btn {
+        border: 1px solid #9fd0c2;
+        border-radius: 999px;
+        background: #eaf8f2;
+        color: #12493d;
+        font: inherit;
+        font-size: 0.82rem;
+        font-weight: 700;
+        padding: 0.5rem 0.9rem;
+        cursor: pointer;
+      }
+
+      .pharmacy-btn:disabled {
+        opacity: 0.65;
+        cursor: wait;
+      }
+
+      .pharmacy-btn.secondary {
+        background: #ffffff;
+        color: #1f5e52;
+        border-color: #b8d8cf;
+      }
+
+      .pharmacy-status {
+        margin-top: 0.6rem;
+        color: #34574f;
+        font-size: 0.84rem;
+      }
+
+      .pharmacy-list {
+        margin-top: 0.72rem;
+        list-style: none;
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .pharmacy-list li {
+        border: 1px solid #dbece6;
+        background: #f8fdfa;
+        border-radius: 10px;
+        padding: 0.6rem 0.7rem;
+      }
+
+      .pharmacy-list strong {
+        font-size: 0.87rem;
+      }
+
+      .pharmacy-list p {
+        margin-top: 0.25rem;
+        color: #48655e;
+        font-size: 0.8rem;
+      }
+
+      .open-flag {
+        display: inline-flex;
+        align-items: center;
+        margin-top: 0.28rem;
+        border-radius: 999px;
+        padding: 0.18rem 0.5rem;
+        font-size: 0.72rem;
+        font-weight: 700;
+      }
+
+      .open-flag.open {
+        background: #e5f9ef;
+        color: #16674f;
+      }
+
+      .open-flag.closed {
+        background: #ffe9e2;
+        color: #8d3920;
+      }
+
+      .pharmacy-map-wrap {
+        margin-top: 0.72rem;
+        border: 1px solid #dbece6;
+        border-radius: 12px;
+        overflow: hidden;
+        background: #f8fdfa;
+      }
+
+      .pharmacy-map {
+        width: 100%;
+        height: 320px;
+      }
+
+      .user-pin-dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        background: #e53935;
+        border: 2px solid #ffffff;
+        box-shadow: 0 0 0 2px rgba(229, 57, 53, 0.3);
+      }
+
       .feature {
         border-radius: 18px;
         padding: 1.15rem;
@@ -510,12 +639,45 @@
           <p>주의문구만 나열하지 않고, 대체 선택지와 확인 포인트를 함께 제공합니다.</p>
         </article>
       </section>
+
+      <section class="panel pharmacy-finder">
+        <div class="pharmacy-head">
+          <div>
+            <h3>현재 위치 기반 근처 약국 찾기</h3>
+            <p>위치 권한 허용 시 가까운 약국 목록을 조회합니다.</p>
+          </div>
+          <div class="pharmacy-actions">
+            <button id="findCurrentLocationBtn" class="pharmacy-btn secondary" type="button">내 위치 찾기</button>
+            <button id="findNearbyPharmacyBtn" class="pharmacy-btn" type="button">근처 약국 찾기</button>
+          </div>
+        </div>
+        <p id="pharmacyStatus" class="pharmacy-status">버튼을 누르면 조회를 시작합니다.</p>
+        <p id="currentLocationText" class="pharmacy-status" hidden></p>
+        <div id="pharmacyMapWrap" class="pharmacy-map-wrap" hidden>
+          <div id="pharmacyMap" class="pharmacy-map" aria-label="근처 약국 지도"></div>
+        </div>
+        <ul id="pharmacyList" class="pharmacy-list" hidden></ul>
+      </section>
     </div>
 
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
       const inputEl = document.getElementById("drugInput");
       const formEl = document.getElementById("searchForm");
       const btnEl = formEl.querySelector(".search-btn");
+      const locateBtnEl = document.getElementById("findCurrentLocationBtn");
+      const pharmacyBtnEl = document.getElementById("findNearbyPharmacyBtn");
+      const pharmacyStatusEl = document.getElementById("pharmacyStatus");
+      const currentLocationTextEl = document.getElementById("currentLocationText");
+      const pharmacyListEl = document.getElementById("pharmacyList");
+      const pharmacyMapWrapEl = document.getElementById("pharmacyMapWrap");
+      let pharmacyMap = null;
+      let userLocationMarker = null;
+      let userLocationIcon = null;
+      let pharmacyMarkers = [];
+      let currentCoords = null;
+      let suppressNextMapMoveFetch = false;
+      let mapMoveRefreshTimer = null;
 
       function setLoadingState(loading) {
         inputEl.disabled = loading;
@@ -552,6 +714,381 @@
           executeSearch();
         });
       });
+
+      function ensurePharmacyMap() {
+        if (!window.L || pharmacyMap) return;
+        pharmacyMap = L.map("pharmacyMap", { zoomControl: true });
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          maxZoom: 19,
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(pharmacyMap);
+
+        userLocationIcon = L.divIcon({
+          className: "user-pin",
+          html: '<div class="user-pin-dot" aria-hidden="true"></div>',
+          iconSize: [18, 18],
+          iconAnchor: [9, 9],
+        });
+
+        pharmacyMap.on("moveend", () => {
+          if (suppressNextMapMoveFetch) {
+            suppressNextMapMoveFetch = false;
+            return;
+          }
+          if (mapMoveRefreshTimer) {
+            clearTimeout(mapMoveRefreshTimer);
+          }
+          mapMoveRefreshTimer = setTimeout(() => {
+            refreshPharmaciesForCurrentMapView();
+          }, 350);
+        });
+      }
+
+      function clearPharmacyMarkers() {
+        if (!pharmacyMap) return;
+        pharmacyMarkers.forEach((marker) => marker.remove());
+        pharmacyMarkers = [];
+      }
+
+      function upsertUserLocationMarker(lat, lng, options = {}) {
+        ensurePharmacyMap();
+        if (!pharmacyMap) return;
+        const openPopup = Boolean(options.openPopup);
+        const latNum = Number(lat);
+        const lngNum = Number(lng);
+        if (!Number.isFinite(latNum) || !Number.isFinite(lngNum)) return;
+
+        if (userLocationMarker) {
+          userLocationMarker.setLatLng([latNum, lngNum]);
+        } else {
+          userLocationMarker = L.marker([latNum, lngNum], {
+            title: "현재 위치",
+            icon: userLocationIcon || undefined,
+          })
+            .addTo(pharmacyMap)
+            .bindPopup("현재 위치");
+        }
+
+        if (openPopup) {
+          userLocationMarker.openPopup();
+        }
+      }
+
+      function setCurrentLocationText(lat, lng) {
+        if (!currentLocationTextEl) return;
+        currentLocationTextEl.hidden = false;
+        currentLocationTextEl.textContent = `현재 위치: ${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+      }
+
+      function showCurrentLocationOnMap(lat, lng) {
+        ensurePharmacyMap();
+        if (!pharmacyMap || !pharmacyMapWrapEl) return;
+
+        upsertUserLocationMarker(lat, lng, { openPopup: true });
+        pharmacyMapWrapEl.hidden = false;
+        setTimeout(() => {
+          pharmacyMap.invalidateSize();
+          suppressNextMapMoveFetch = true;
+          pharmacyMap.setView([lat, lng], 15);
+        }, 0);
+      }
+
+      function getPosition() {
+        return new Promise((resolve, reject) =>
+          navigator.geolocation.getCurrentPosition(resolve, reject, {
+            enableHighAccuracy: true,
+            timeout: 12000,
+            maximumAge: 60000,
+          })
+        );
+      }
+
+      async function resolveCurrentLocation(options = {}) {
+        const silent = Boolean(options.silent);
+        if (!window.isSecureContext) {
+          if (!silent) {
+            pharmacyStatusEl.textContent = "위치 조회는 HTTPS 또는 localhost 환경에서만 동작합니다.";
+          }
+          throw new Error("insecure_context");
+        }
+        if (!navigator.geolocation) {
+          if (!silent) {
+            pharmacyStatusEl.textContent = "이 브라우저에서는 위치 조회를 지원하지 않습니다.";
+          }
+          throw new Error("geolocation_not_supported");
+        }
+
+        if (!silent) {
+          pharmacyStatusEl.textContent = "현재 위치를 확인 중입니다...";
+        }
+        const pos = await getPosition();
+        const lat = Number(pos.coords.latitude);
+        const lng = Number(pos.coords.longitude);
+        currentCoords = { lat, lng };
+        setCurrentLocationText(lat, lng);
+        showCurrentLocationOnMap(lat, lng);
+        if (!silent) {
+          pharmacyStatusEl.textContent = "현재 위치를 확인했습니다. 근처 약국 찾기를 눌러 조회하세요.";
+        }
+        return currentCoords;
+      }
+
+      function renderNearbyPharmacies(items, userLat, userLng, options = {}) {
+        pharmacyListEl.innerHTML = "";
+        const list = Array.isArray(items) ? items : [];
+        const fitMap = options.fitMap !== false;
+        const listLimit = Number(options.listLimit || 5);
+        ensurePharmacyMap();
+        clearPharmacyMarkers();
+
+        const userLatNum = Number(userLat);
+        const userLngNum = Number(userLng);
+        if (Number.isFinite(userLatNum) && Number.isFinite(userLngNum)) {
+          upsertUserLocationMarker(userLatNum, userLngNum);
+        }
+
+        if (!list.length) {
+          pharmacyListEl.hidden = true;
+          if (pharmacyMapWrapEl && pharmacyMap) {
+            pharmacyMapWrapEl.hidden = !userLocationMarker;
+            if (userLocationMarker) {
+              setTimeout(() => {
+                pharmacyMap.invalidateSize();
+                pharmacyMap.setView(userLocationMarker.getLatLng(), 15);
+              }, 0);
+            }
+          }
+          return;
+        }
+
+        const top = list.slice(0, Math.max(1, Math.min(listLimit, list.length)));
+        top.forEach((item) => {
+          const li = document.createElement("li");
+          const name = (item && (item.name || item.place_name)) || "약국";
+          const address = (item && (item.address || item.vicinity || item.formatted_address)) || "주소 정보 없음";
+          const phone = (item && (item.phone || item.formatted_phone_number)) || "";
+          const hours = (item && (item.opening_hours_text || item.opening_hours)) || "";
+          const openNow = item && typeof item.open_now === "boolean" ? item.open_now : null;
+          const openFlag = openNow === null
+            ? ""
+            : `<span class="open-flag ${openNow ? "open" : "closed"}">${openNow ? "영업 중" : "영업 종료"}</span>`;
+          li.innerHTML = `<strong>${name}</strong>${openFlag}<p>${address}</p>${phone ? `<p>전화: ${phone}</p>` : ""}<p>운영시간: ${hours || "정보 없음"}</p>`;
+          pharmacyListEl.appendChild(li);
+        });
+
+        if (pharmacyMap && pharmacyMapWrapEl) {
+          const bounds = [];
+          if (userLocationMarker) {
+            bounds.push(userLocationMarker.getLatLng());
+          }
+
+          list.forEach((item) => {
+            const lat = Number(item && item.lat);
+            const lng = Number(item && item.lng);
+            if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+
+            const marker = L.marker([lat, lng], { title: item.name || "약국" }).addTo(pharmacyMap);
+            const popupName = item.name || "약국";
+            const popupAddress = item.address || item.vicinity || item.formatted_address || "";
+            const popupPhone = item.phone || item.formatted_phone_number || "";
+            const popupHours = item.opening_hours_text || item.opening_hours || "";
+            const popupOpen = typeof item.open_now === "boolean"
+              ? `<br/>${item.open_now ? "영업 중" : "영업 종료"}`
+              : "";
+            marker.bindPopup(
+              `<strong>${popupName}</strong>${popupAddress ? `<br/>${popupAddress}` : ""}${popupPhone ? `<br/>전화: ${popupPhone}` : ""}${popupHours ? `<br/>운영시간: ${popupHours}` : ""}${popupOpen}`
+            );
+            marker.bindTooltip(
+              `<strong>${popupName}</strong>${popupAddress ? `<br/>${popupAddress}` : ""}${popupHours ? `<br/>운영시간: ${popupHours}` : ""}`,
+              { direction: "top", sticky: true, opacity: 0.95 }
+            );
+            pharmacyMarkers.push(marker);
+            bounds.push(marker.getLatLng());
+          });
+
+          pharmacyMapWrapEl.hidden = false;
+          if (fitMap) {
+            setTimeout(() => {
+              pharmacyMap.invalidateSize();
+              suppressNextMapMoveFetch = true;
+              if (bounds.length >= 2) {
+                pharmacyMap.fitBounds(bounds, { padding: [28, 28] });
+              } else if (bounds.length === 1) {
+                pharmacyMap.setView(bounds[0], 15);
+              }
+            }, 0);
+          }
+        }
+
+        pharmacyListEl.hidden = false;
+      }
+
+      function getMapQueryFromView() {
+        if (!pharmacyMap) return null;
+        const center = pharmacyMap.getCenter();
+        const bounds = pharmacyMap.getBounds();
+        const northEast = bounds.getNorthEast();
+        const distance = center.distanceTo(northEast);
+        const radius = Math.max(500, Math.min(Math.round(distance), 10000));
+        return {
+          lat: Number(center.lat),
+          lng: Number(center.lng),
+          radius,
+          limit: 20,
+        };
+      }
+
+      async function fetchNearbyPharmaciesByQuery(query, options = {}) {
+        const lat = Number(query && query.lat);
+        const lng = Number(query && query.lng);
+        const radius = Number(query && query.radius);
+        const limit = Number(query && query.limit);
+        const userLat = Number(options.userLat);
+        const userLng = Number(options.userLng);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return [];
+
+        const url = `/api/pharmacies/?lat=${encodeURIComponent(lat)}&lng=${encodeURIComponent(lng)}&radius=${encodeURIComponent(
+          Number.isFinite(radius) ? radius : 3000
+        )}&limit=${encodeURIComponent(Number.isFinite(limit) ? limit : 10)}`;
+        const res = await fetch(url, {
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        const data = await res.json();
+        if (!res.ok || data.status !== "success") {
+          throw new Error(data.message || "약국 조회 실패");
+        }
+
+        renderNearbyPharmacies(
+          data.results || [],
+          Number.isFinite(userLat) ? userLat : lat,
+          Number.isFinite(userLng) ? userLng : lng,
+          {
+          fitMap: options.fitMap !== false,
+          listLimit: Number(options.listLimit || 5),
+          }
+        );
+        return Array.isArray(data.results) ? data.results : [];
+      }
+
+      async function refreshPharmaciesForCurrentMapView() {
+        if (!pharmacyMap || pharmacyMapWrapEl.hidden) return;
+        const query = getMapQueryFromView();
+        if (!query) return;
+        try {
+          pharmacyStatusEl.textContent = "지도의 현재 영역 기준으로 약국을 다시 조회 중입니다...";
+          const results = await fetchNearbyPharmaciesByQuery(query, {
+            fitMap: false,
+            listLimit: 10,
+            userLat: currentCoords && currentCoords.lat,
+            userLng: currentCoords && currentCoords.lng,
+          });
+          if (results.length) {
+            pharmacyStatusEl.textContent = `현재 지도 영역에서 약국 ${Math.min(results.length, 10)}곳을 표시했습니다.`;
+          } else {
+            pharmacyStatusEl.textContent = "현재 지도 영역에서 약국을 찾지 못했습니다.";
+          }
+        } catch (_) {
+          pharmacyStatusEl.textContent = "지도 이동 후 약국 재조회에 실패했습니다.";
+        }
+      }
+
+      async function requestNearbyPharmacies() {
+        let lat = null;
+        let lng = null;
+        pharmacyBtnEl.disabled = true;
+        if (locateBtnEl) {
+          locateBtnEl.disabled = true;
+        }
+        pharmacyStatusEl.textContent = "현재 위치를 확인 중입니다...";
+
+        try {
+          const coords = currentCoords || (await resolveCurrentLocation({ silent: true }));
+          lat = Number(coords.lat);
+          lng = Number(coords.lng);
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+            throw new Error("invalid_coordinates");
+          }
+          setCurrentLocationText(lat, lng);
+          pharmacyStatusEl.textContent = "근처 약국 정보를 조회 중입니다...";
+          const dataResults = await fetchNearbyPharmaciesByQuery(
+            {
+              lat,
+              lng,
+              radius: 3000,
+              limit: 15,
+            },
+            {
+              fitMap: true,
+              listLimit: 10,
+              userLat: lat,
+              userLng: lng,
+            }
+          );
+          if (Array.isArray(dataResults) && dataResults.length) {
+            pharmacyStatusEl.textContent = `가까운 약국 ${Math.min(dataResults.length, 10)}곳을 표시했습니다.`;
+          } else {
+            pharmacyStatusEl.textContent = "근처 약국을 찾지 못했습니다. 잠시 후 다시 시도해 주세요.";
+          }
+        } catch (error) {
+          const code = Number(error && error.code);
+          if (code === 1) {
+            pharmacyStatusEl.textContent = "위치 권한이 거부되었습니다. 브라우저에서 위치 권한을 허용해 주세요.";
+          } else if (code === 2) {
+            pharmacyStatusEl.textContent = "현재 위치를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+          } else if (code === 3) {
+            pharmacyStatusEl.textContent = "위치 조회 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.";
+          } else {
+            pharmacyStatusEl.textContent = "위치 권한 또는 네트워크 문제로 약국 조회에 실패했습니다.";
+          }
+          pharmacyListEl.hidden = true;
+          if (pharmacyMapWrapEl) {
+            pharmacyMapWrapEl.hidden = !userLocationMarker;
+          }
+          clearPharmacyMarkers();
+        } finally {
+          pharmacyBtnEl.disabled = false;
+          if (locateBtnEl) {
+            locateBtnEl.disabled = false;
+          }
+        }
+      }
+
+      if (locateBtnEl) {
+        locateBtnEl.addEventListener("click", async () => {
+          locateBtnEl.disabled = true;
+          if (pharmacyBtnEl) {
+            pharmacyBtnEl.disabled = true;
+          }
+          try {
+            await resolveCurrentLocation();
+          } catch (error) {
+            const code = Number(error && error.code);
+            if (code === 1) {
+              pharmacyStatusEl.textContent = "위치 권한이 거부되었습니다. 브라우저에서 위치 권한을 허용해 주세요.";
+            } else if (code === 2) {
+              pharmacyStatusEl.textContent = "현재 위치를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+            } else if (code === 3) {
+              pharmacyStatusEl.textContent = "위치 조회 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.";
+            } else if (String(error && error.message) === "insecure_context") {
+              pharmacyStatusEl.textContent = "위치 조회는 HTTPS 또는 localhost 환경에서만 동작합니다.";
+            } else if (String(error && error.message) === "geolocation_not_supported") {
+              pharmacyStatusEl.textContent = "이 브라우저에서는 위치 조회를 지원하지 않습니다.";
+            } else {
+              pharmacyStatusEl.textContent = "현재 위치 조회에 실패했습니다.";
+            }
+          } finally {
+            locateBtnEl.disabled = false;
+            if (pharmacyBtnEl) {
+              pharmacyBtnEl.disabled = false;
+            }
+          }
+        });
+      }
+
+      if (pharmacyBtnEl) {
+        pharmacyBtnEl.addEventListener("click", requestNearbyPharmacies);
+      }
     </script>
   </body>
 </html>
+

--- a/skn22_4th_prj/templates/symptom_products_page.html
+++ b/skn22_4th_prj/templates/symptom_products_page.html
@@ -1,0 +1,725 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>복용 가능 성분 제품 추천 - {{ symptom }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --ink-950: #08241f;
+        --ink-700: #335951;
+        --line: #d2e7df;
+        --safe-700: #156d45;
+        --safe-100: #e9f8ef;
+        --warn-700: #9a2e2e;
+        --warn-100: #fff4f4;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        min-height: 100vh;
+        font-family: "Sora", "Noto Sans KR", sans-serif;
+        color: var(--ink-950);
+        background:
+          radial-gradient(900px 420px at 108% -8%, #d9fff3 0%, transparent 62%),
+          radial-gradient(760px 360px at -8% 112%, #ffe5cc 0%, transparent 60%),
+          #f2faf7;
+      }
+
+      .wrap {
+        width: min(1140px, calc(100% - 2rem));
+        margin: 1rem auto 2rem;
+      }
+
+      .top-links {
+        display: flex;
+        gap: 0.6rem;
+        margin-bottom: 0.9rem;
+        flex-wrap: wrap;
+      }
+
+      .top-links a {
+        text-decoration: none;
+        color: #1a5449;
+        border: 1px solid #b7dbcf;
+        background: #f4fcf9;
+        border-radius: 999px;
+        font-weight: 700;
+        font-size: 0.83rem;
+        padding: 0.3rem 0.72rem;
+      }
+
+      .hero,
+      .card,
+      .blocked {
+        background: #fff;
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        box-shadow: 0 16px 36px rgba(4, 37, 32, 0.08);
+      }
+
+      .hero {
+        padding: 1.15rem 1.2rem;
+        margin-bottom: 1rem;
+      }
+
+      .hero h1 {
+        font-size: clamp(1.35rem, 3vw, 1.82rem);
+      }
+
+      .hero p {
+        margin-top: 0.4rem;
+        color: var(--ink-700);
+        font-size: 0.9rem;
+      }
+
+      .status {
+        margin-top: 0.62rem;
+        color: #1f5f53;
+        font-size: 0.84rem;
+        line-height: 1.5;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.68fr) minmax(300px, 1fr);
+        gap: 1rem;
+        align-items: start;
+      }
+
+      .stack {
+        display: grid;
+        gap: 0.85rem;
+      }
+
+      .card {
+        padding: 0.92rem 0.98rem;
+      }
+
+      .hidden-card {
+        display: none;
+      }
+
+      .head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.6rem;
+      }
+
+      .name {
+        font-size: 1.05rem;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+
+      .badge {
+        display: inline-flex;
+        border-radius: 999px;
+        padding: 0.2rem 0.55rem;
+        font-size: 0.73rem;
+        font-weight: 700;
+        background: var(--safe-100);
+        color: var(--safe-700);
+      }
+
+      .slot {
+        margin-top: 0.7rem;
+      }
+
+      .section-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: #2a5d52;
+        margin-bottom: 0.5rem;
+      }
+
+      .products {
+        list-style: none;
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .products li {
+        border: 1px solid #dbece6;
+        border-radius: 12px;
+        background: #f8fdfa;
+        padding: 0.6rem;
+      }
+
+      .product-main {
+        min-width: 0;
+      }
+
+      .product-title {
+        font-size: 0.88rem;
+        font-weight: 800;
+        color: #123f37;
+        text-decoration: none;
+        word-break: break-word;
+      }
+
+      .product-title:hover {
+        text-decoration: underline;
+      }
+
+      .meta {
+        margin-top: 0.19rem;
+        color: #49675f;
+        font-size: 0.8rem;
+        line-height: 1.42;
+      }
+
+      .meta-label {
+        color: #2e554d;
+        font-weight: 700;
+      }
+
+      .raw-en {
+        font-family: "Sora", sans-serif;
+        letter-spacing: 0.01em;
+        word-break: break-word;
+      }
+
+      .efficacy-summary {
+        margin-top: 0.25rem;
+        color: #365850;
+      }
+
+      .links {
+        margin-top: 0.27rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.38rem;
+      }
+
+      .links a {
+        text-decoration: none;
+        color: #1f5f53;
+        font-size: 0.74rem;
+        font-weight: 700;
+        border: 1px solid #bde3d7;
+        border-radius: 8px;
+        padding: 0.12rem 0.42rem;
+        background: #fff;
+      }
+
+      .links a:hover {
+        text-decoration: underline;
+      }
+
+      .rank {
+        margin-top: 0.23rem;
+        color: #7a4a00;
+        font-size: 0.75rem;
+        font-weight: 700;
+      }
+
+      .empty {
+        color: #4f6f67;
+        font-size: 0.9rem;
+      }
+
+      .blocked {
+        padding: 0.95rem 1rem;
+        position: sticky;
+        top: 1rem;
+      }
+
+      .blocked h2 {
+        font-size: 1rem;
+      }
+
+      .blocked ul {
+        margin-top: 0.62rem;
+        list-style: none;
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .blocked li {
+        border: 1px solid #ffd7d7;
+        background: var(--warn-100);
+        border-radius: 10px;
+        padding: 0.55rem;
+      }
+
+      .blocked strong {
+        color: var(--warn-700);
+      }
+
+      .excluded-products {
+        margin-top: 0.46rem;
+        border: 1px solid #ffd8d8;
+        background: #fff7f7;
+        border-radius: 9px;
+        padding: 0.45rem 0.52rem;
+      }
+
+      .excluded-products strong {
+        display: block;
+        font-size: 0.77rem;
+        color: #8f2323;
+      }
+
+      .excluded-products ul {
+        list-style: none;
+        margin-top: 0.3rem;
+        display: grid;
+        gap: 0.25rem;
+      }
+
+      .excluded-products li {
+        border: 0;
+        background: transparent;
+        padding: 0;
+        font-size: 0.78rem;
+        color: #7f2b2b;
+      }
+
+      .product-dur-note {
+        margin-top: 0.35rem;
+        border: 1px solid #ffd9d9;
+        background: #fff5f5;
+        border-radius: 8px;
+        padding: 0.3rem 0.45rem;
+        color: #8f2323;
+        font-size: 0.79rem;
+      }
+
+      @media (max-width: 980px) {
+        .wrap {
+          width: min(1140px, calc(100% - 1rem));
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+
+        .blocked {
+          position: static;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <div class="top-links">
+        <a href="/smart-search/?q={{ symptom|urlencode }}">&larr; 성분 선정으로 돌아가기</a>
+        <a href="/">&larr; 메인으로</a>
+      </div>
+
+      <section class="hero">
+        <h1>복용 가능 성분 제품 추천</h1>
+        <p>입력 증상: "{{ symptom }}"</p>
+        <p id="productsStatus" class="status">
+          복용 가능 후보를 조회 중입니다. 후보군에서 제품이 확인된 성분 최대 5개를 자동으로 표시합니다.
+        </p>
+      </section>
+
+      <section class="grid">
+        <section class="stack">
+          {% for ing in ingredients_data %}
+          {% if ing.can_take %}
+          <article
+            class="card{% if forloop.counter > 5 %} hidden-card{% endif %}"
+            data-ingredient="{{ ing.name }}"
+            data-candidate-order="{{ forloop.counter0 }}"
+            data-has-products="-1"
+          >
+            <div class="head">
+              <div class="name">{{ ing.name }}</div>
+              <span class="badge">복용 가능</span>
+            </div>
+            <div class="slot" data-role="product-slot">
+              <p class="empty">제품 조회 중...</p>
+            </div>
+          </article>
+          {% endif %}
+          {% endfor %}
+        </section>
+
+        <section class="blocked">
+          <h2>복용 제한 성분 안내</h2>
+          <ul>
+            {% for ing in ingredients_data %}
+            {% if not ing.can_take %}
+            <li>
+              <strong>{{ ing.name }}</strong>
+              <div class="meta">{{ ing.reason }}</div>
+            </li>
+            {% endif %}
+            {% empty %}
+            <li class="empty">복용 제한 성분이 없습니다.</li>
+            {% endfor %}
+          </ul>
+        </section>
+      </section>
+    </main>
+
+    {{ ingredients_data|json_script:"ingredients-data-json" }}
+
+    <script>
+      function escapeHtml(value) {
+        return String(value || "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+      }
+
+      function toEnglishRaw(value, fallback) {
+        const raw = String(value || "").trim();
+        if (raw) return raw;
+        return String(fallback || "");
+      }
+
+      function summarizeEfficacy(summaryKr, purpose) {
+        const source = String(summaryKr || purpose || "")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (!source) {
+          return "효능 요약 정보를 불러오지 못했습니다. 복용 전 용법·용량과 주의사항을 확인하세요.";
+        }
+
+        const sentence = source.match(/^(.+?[.!?。！？])(\s|$)/);
+        let brief = sentence ? sentence[1] : source;
+        brief = brief.replace(/^효능(\/효과)?[:：]\s*/i, "").trim();
+
+        const maxLen = 96;
+        if (brief.length > maxLen) {
+          brief = `${brief.slice(0, maxLen - 1).trim()}…`;
+        }
+        return brief;
+      }
+
+      const TARGET_VISIBLE_PRODUCT_CARDS = 5;
+
+      function getIngredientCards() {
+        return Array.from(document.querySelectorAll(".card[data-ingredient]"));
+      }
+
+      function markCardProductState(ingredient, hasProducts) {
+        const ingUpper = String(ingredient || "").trim().toUpperCase();
+        const card = getIngredientCards().find(
+          (el) => String(el.dataset.ingredient || "").trim().toUpperCase() === ingUpper
+        );
+        if (!card) return;
+        card.dataset.hasProducts = hasProducts ? "1" : "0";
+      }
+
+      function setBackfillCardVisibility() {
+        const cards = getIngredientCards();
+        if (!cards.length) return;
+
+        const withProducts = cards.filter((card) => card.dataset.hasProducts === "1");
+        const pending = cards.filter((card) => card.dataset.hasProducts !== "1" && card.dataset.hasProducts !== "0");
+        const withoutProducts = cards.filter((card) => card.dataset.hasProducts === "0");
+        const ordered = [...withProducts, ...pending, ...withoutProducts];
+
+        ordered.forEach((card, idx) => {
+          card.classList.toggle("hidden-card", idx >= TARGET_VISIBLE_PRODUCT_CARDS);
+        });
+      }
+
+      function updateProductCard(ingredient, payloadItem) {
+        const cards = Array.from(document.querySelectorAll(".card[data-ingredient]"));
+        const card = cards.find((el) => (el.dataset.ingredient || "").toUpperCase() === ingredient.toUpperCase());
+        if (!card) return;
+        const slot = card.querySelector('[data-role="product-slot"]');
+        if (!slot) return;
+
+        const products = Array.isArray(payloadItem?.products) ? payloadItem.products : [];
+        const excludedProducts = Array.isArray(payloadItem?.excluded_products_due_to_other_component_dur)
+          ? payloadItem.excluded_products_due_to_other_component_dur
+          : [];
+        const ingredientNotice = escapeHtml(payloadItem?.other_component_dur_notice || "");
+        markCardProductState(ingredient, products.length > 0);
+
+        const excludedItemsHtml = excludedProducts
+          .map((x) => {
+            const brand = escapeHtml(x.brand_name || "Unknown Product");
+            const riskComponents = Array.isArray(x.risk_components) ? x.risk_components : [];
+            const reasonText =
+              riskComponents
+                .map((r) => {
+                  const n = escapeHtml(r.name || "");
+                  const t = Array.isArray(r.types) && r.types.length ? ` (${escapeHtml(r.types.join(", "))})` : "";
+                  return `${n}${t}`;
+                })
+                .filter(Boolean)
+                .join(", ") || escapeHtml(x.reason || "추가 주성분 DUR 위험");
+            return `<li><strong>${brand}</strong> - 제외 사유: ${reasonText}</li>`;
+          })
+          .join("");
+
+        if (!products.length) {
+          if (excludedProducts.length) {
+            slot.innerHTML = `
+              <p class="empty">추천 후보가 추가 주성분 DUR 위험으로 제외되었습니다.</p>
+              <div class="excluded-products">
+                <strong>제외된 제품 사유</strong>
+                <ul>${excludedItemsHtml}</ul>
+              </div>
+            `;
+            setBackfillCardVisibility();
+            return;
+          }
+          slot.innerHTML = "<p class=\"empty\">검색된 OTC 제품이 없습니다.</p>";
+          setBackfillCardVisibility();
+          return;
+        }
+
+        const items = products
+          .slice(0, 3)
+          .map((prod) => {
+            const brandRaw = toEnglishRaw(prod.brand_name, "Unknown Product");
+            const manufacturerRaw = toEnglishRaw(prod.manufacturer_name, "Unknown Manufacturer");
+            const brand = escapeHtml(brandRaw);
+            const manufacturer = escapeHtml(manufacturerRaw);
+            const amazonUrl = escapeHtml(prod.amazon_url || "");
+            const dailymedUrl = escapeHtml(prod.dailymed_url || "");
+            const rankLabel = escapeHtml(prod.amazon_rank_label || "");
+            const efficacySummary = escapeHtml(summarizeEfficacy(prod.summary_kr || "", prod.purpose || ""));
+
+            const titleUrl = amazonUrl || dailymedUrl;
+            const titleHtml = titleUrl
+              ? `<a class="product-title raw-en" href="${titleUrl}" target="_blank" rel="noopener noreferrer">${brand}</a>`
+              : `<span class="product-title raw-en">${brand}</span>`;
+            const links = [
+              amazonUrl ? `<a href="${amazonUrl}" target="_blank" rel="noopener noreferrer">아마존 상세</a>` : "",
+              dailymedUrl ? `<a href="${dailymedUrl}" target="_blank" rel="noopener noreferrer">DailyMed 정보</a>` : "",
+            ]
+              .filter(Boolean)
+              .join("");
+            const linksHtml = links ? `<p class="links">${links}</p>` : "";
+            const rankHtml = rankLabel ? `<p class="rank">Amazon BSR: ${rankLabel}</p>` : "";
+
+            return `
+              <li>
+                <div class="product-main">
+                  ${titleHtml}
+                  <p class="meta"><span class="meta-label">제조사(EN):</span> <span class="raw-en">${manufacturer}</span></p>
+                  ${linksHtml}
+                </div>
+                ${rankHtml}
+                <p class="meta efficacy-summary"><span class="meta-label">효능 요약:</span> ${efficacySummary}</p>
+              </li>
+            `;
+          })
+          .join("");
+
+        const noticeHtml = ingredientNotice ? `<p class="product-dur-note">${ingredientNotice}</p>` : "";
+        const excludedSection = excludedProducts.length
+          ? `<div class="excluded-products"><strong>추가 주성분 DUR 위험으로 제외된 제품 ${excludedProducts.length}개</strong><ul>${excludedItemsHtml}</ul></div>`
+          : "";
+
+        slot.innerHTML = `<h3 class="section-title">추천 OTC 제품</h3>${noticeHtml}<ul class="products">${items}</ul>${excludedSection}`;
+        setBackfillCardVisibility();
+      }
+
+      function buildProductPrefetchKey(symptom, ingredients) {
+        const normalizedSymptom = String(symptom || "").trim().toUpperCase();
+        const normalizedIngredients = (ingredients || [])
+          .map((x) => String(x || "").trim().toUpperCase())
+          .filter(Boolean)
+          .join(",");
+        return `symptom-products-prefetch::${normalizedSymptom}::${normalizedIngredients}`;
+      }
+
+      function loadPrefetchedItems(symptom, safeIngredients) {
+        const storageKey = buildProductPrefetchKey(symptom, safeIngredients);
+        try {
+          const raw = sessionStorage.getItem(storageKey);
+          if (!raw) return { items: [], fetchedIngredients: [], prefetchComplete: false };
+          const parsed = JSON.parse(raw);
+          const cachedAt = Number(parsed?.cached_at || 0);
+          const maxAgeMs = 5 * 60 * 1000;
+          if (!Array.isArray(parsed?.items) || cachedAt <= 0 || Date.now() - cachedAt > maxAgeMs) {
+            return { items: [], fetchedIngredients: [], prefetchComplete: false };
+          }
+          if (Number(parsed?.schema_version || 0) < 2) {
+            return { items: [], fetchedIngredients: [], prefetchComplete: false };
+          }
+          const fetchedIngredients = Array.isArray(parsed?.fetched_ingredients)
+            ? parsed.fetched_ingredients.map((x) => String(x || "").trim().toUpperCase()).filter(Boolean)
+            : [];
+          return {
+            items: parsed.items,
+            fetchedIngredients,
+            prefetchComplete: Boolean(parsed?.prefetch_complete),
+          };
+        } catch (_) {
+          return { items: [], fetchedIngredients: [], prefetchComplete: false };
+        }
+      }
+
+      function savePrefetchedItems(symptom, safeIngredients, itemMap, prefetchComplete) {
+        const storageKey = buildProductPrefetchKey(symptom, safeIngredients);
+        try {
+          const orderedItems = safeIngredients
+            .map((ingredient) => itemMap.get(ingredient))
+            .filter(Boolean);
+          const fetchedIngredients = orderedItems
+            .map((item) => String(item?.ingredient || "").trim().toUpperCase())
+            .filter(Boolean);
+
+          sessionStorage.setItem(
+            storageKey,
+            JSON.stringify({
+              schema_version: 2,
+              symptom,
+              ingredients: safeIngredients,
+              items: orderedItems,
+              fetched_ingredients: fetchedIngredients,
+              prefetch_complete: Boolean(prefetchComplete),
+              cached_at: Date.now(),
+            })
+          );
+          sessionStorage.setItem("symptom-products-prefetch-latest-key", storageKey);
+        } catch (_) {
+          // Ignore storage quota / serialization errors.
+        }
+      }
+
+      async function initProducts() {
+        const statusEl = document.getElementById("productsStatus");
+        const dataNode = document.getElementById("ingredients-data-json");
+        if (!dataNode) return;
+
+        let ingredientsData = [];
+        try {
+          ingredientsData = JSON.parse(dataNode.textContent || "[]");
+        } catch (_) {
+          ingredientsData = [];
+        }
+
+        const toCanTake = (value) => {
+          if (typeof value === "boolean") return value;
+          const token = String(value || "").trim().toLowerCase();
+          return ["true", "1", "yes", "y", "on"].includes(token);
+        };
+
+        const safeIngredients = ingredientsData
+          .filter((ing) => ing && ing.name && toCanTake(ing.can_take))
+          .map((ing) => String(ing.name).trim().toUpperCase());
+        setBackfillCardVisibility();
+
+        if (!safeIngredients.length) {
+          if (statusEl) statusEl.textContent = "복용 가능 성분이 없어 제품 조회를 생략했습니다.";
+          return;
+        }
+
+        const symptomTerm = "{{ symptom|escapejs }}";
+        const safeIngredientSet = new Set(safeIngredients);
+        const renderedIngredients = new Set();
+        let successCount = 0;
+        const itemMap = new Map();
+
+        const prefetched = loadPrefetchedItems(symptomTerm, safeIngredients);
+        const prefetchedItems = Array.isArray(prefetched.items) ? prefetched.items : [];
+        const prefetchedIngredientSet = new Set(
+          Array.isArray(prefetched.fetchedIngredients) ? prefetched.fetchedIngredients : []
+        );
+
+        if (prefetchedItems.length) {
+          prefetchedItems.forEach((item) => {
+            const ingredient = String(item?.ingredient || "").trim().toUpperCase();
+            if (!ingredient || !safeIngredientSet.has(ingredient)) return;
+            updateProductCard(ingredient, item || {});
+            renderedIngredients.add(ingredient);
+            itemMap.set(ingredient, item || { ingredient, products: [] });
+            const count = Array.isArray(item?.products) ? item.products.length : 0;
+            if (count > 0) successCount += 1;
+          });
+
+          if (statusEl) {
+            statusEl.textContent = `미리 조회된 결과를 먼저 표시했습니다. (후보 ${safeIngredients.length}개, 화면 최대 ${TARGET_VISIBLE_PRODUCT_CARDS}개)`;
+          }
+        }
+
+        const remainingIngredients = safeIngredients.filter((ingredient) => {
+          if (renderedIngredients.has(ingredient)) return false;
+          if (prefetched.prefetchComplete && prefetchedIngredientSet.has(ingredient)) return false;
+          return true;
+        });
+
+        if (!remainingIngredients.length) {
+          savePrefetchedItems(symptomTerm, safeIngredients, itemMap, true);
+          if (statusEl) {
+            statusEl.textContent = `복용 가능 후보 ${safeIngredients.length}개 중 제품이 확인된 성분은 ${successCount}개이며, 화면에는 최대 ${TARGET_VISIBLE_PRODUCT_CARDS}개를 표시합니다.`;
+          }
+          return;
+        }
+
+        const firstBatchSize = 2;
+        const nextBatchSize = 3;
+        const batches = [];
+        batches.push(remainingIngredients.slice(0, firstBatchSize));
+        for (let i = firstBatchSize; i < remainingIngredients.length; i += nextBatchSize) {
+          batches.push(remainingIngredients.slice(i, i + nextBatchSize));
+        }
+
+        for (let batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
+          const batchIngredients = batches[batchIndex].filter(Boolean);
+          if (!batchIngredients.length) continue;
+          if (statusEl) {
+            statusEl.textContent = `제품 정보를 ${batchIndex + 1}/${batches.length} 단계로 조회 중입니다.`;
+          }
+
+          try {
+            const url = `/api/symptom-products/?ingredients=${encodeURIComponent(batchIngredients.join(","))}&symptom=${encodeURIComponent(symptomTerm)}`;
+            const res = await fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } });
+            const payload = await res.json();
+            if (!res.ok || payload.status !== "success") {
+              throw new Error(payload.message || "Failed to load products");
+            }
+
+            const items = Array.isArray(payload.items) ? payload.items : [];
+            items.forEach((item) => {
+              const ingredient = String(item?.ingredient || "").toUpperCase();
+              if (!ingredient || !safeIngredientSet.has(ingredient)) return;
+              updateProductCard(ingredient, item || {});
+              renderedIngredients.add(ingredient);
+              itemMap.set(ingredient, item || { ingredient, products: [] });
+              const count = Array.isArray(item?.products) ? item.products.length : 0;
+              if (count > 0) successCount += 1;
+            });
+          } catch (_) {
+            batchIngredients.forEach((ingredient) => {
+              if (!safeIngredientSet.has(ingredient)) return;
+              const fallbackItem = { ingredient, products: [] };
+              updateProductCard(ingredient, fallbackItem);
+              renderedIngredients.add(ingredient);
+              itemMap.set(ingredient, fallbackItem);
+            });
+          }
+          savePrefetchedItems(symptomTerm, safeIngredients, itemMap, false);
+        }
+
+        savePrefetchedItems(symptomTerm, safeIngredients, itemMap, true);
+        if (statusEl) {
+          statusEl.textContent = `복용 가능 후보 ${safeIngredients.length}개 중 제품이 확인된 성분은 ${successCount}개이며, 화면에는 최대 ${TARGET_VISIBLE_PRODUCT_CARDS}개를 표시합니다.`;
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        initProducts();
+      });
+    </script>
+  </body>
+</html>

--- a/skn22_4th_prj/templates/symptom_result.html
+++ b/skn22_4th_prj/templates/symptom_result.html
@@ -53,6 +53,28 @@
         font-size: 0.9rem;
       }
 
+      .action-row {
+        margin-top: 0.75rem;
+      }
+
+      .primary-link-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        text-decoration: none;
+        padding: 0.5rem 0.85rem;
+        border-radius: 10px;
+        border: 1px solid #9fd0c2;
+        background: #e8f6f1;
+        color: #11453b;
+        font-weight: 800;
+        font-size: 0.84rem;
+      }
+
+      .primary-link-btn:hover {
+        background: #def1ea;
+      }
+
       .hero,
       .card,
       .notice,
@@ -596,6 +618,56 @@
         line-height: 1.55;
       }
 
+      .consult-panel {
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 16px;
+        border: 1px solid #c9e6dc;
+        background: #f3fcf8;
+      }
+
+      .consult-panel h3 {
+        font-size: 0.95rem;
+        color: #1a5549;
+      }
+
+      .consult-meta {
+        margin-top: 0.55rem;
+        display: grid;
+        gap: 0.22rem;
+      }
+
+      .consult-meta p {
+        margin: 0;
+        color: #3d6159;
+        font-size: 0.83rem;
+      }
+
+      .consult-text {
+        margin-top: 0.65rem;
+        border: 1px solid #d1e9df;
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 0.7rem;
+        white-space: pre-wrap;
+        color: #224740;
+        line-height: 1.55;
+        font-size: 0.86rem;
+      }
+
+      .consult-copy-btn {
+        margin-top: 0.58rem;
+        border: 1px solid #9fd0c2;
+        background: #eaf8f2;
+        color: #12493d;
+        border-radius: 10px;
+        font: inherit;
+        font-size: 0.8rem;
+        font-weight: 700;
+        padding: 0.44rem 0.7rem;
+        cursor: pointer;
+      }
+
       @media (max-width: 980px) {
         .wrap {
           width: min(1160px, calc(100% - 1rem));
@@ -628,9 +700,27 @@
         <div class="answer">{{ answer }}</div>
         {% endif %}
         <p id="asyncDurMergeStatus" style="margin-top:0.6rem;color:#2d5b52;font-size:0.84rem;">
-          한국 DUR 기준 성분 안내를 먼저 표시합니다. 미국 OTC 제품 및 미국 경고 정보는 추가 조회 중입니다.
+          복용 가능 성분을 우선 표시하며, 제품 추천 정보는 이 페이지 로드와 동시에 조회를 시작합니다.
+        </p>
+        <p class="action-row">
+          <a id="productsPageLink" class="primary-link-btn" href="{% url 'chat:symptom_products_page' %}">복용 가능 성분 제품 추천 보기</a>
         </p>
       </section>
+
+      {% if consultation_note %}
+      <section class="consult-panel">
+        <h3>의사/약사 상담용 요약 메모</h3>
+        <div class="consult-meta">
+          <p><strong>증상:</strong> {{ consultation_note.symptom }}</p>
+          <p><strong>복용 중인 약:</strong> {{ consultation_note.meds }}</p>
+          <p><strong>알레르기:</strong> {{ consultation_note.allergies }}</p>
+          <p><strong>기저질환:</strong> {{ consultation_note.diseases }}</p>
+          <p><strong>임신/수유 여부:</strong> {{ consultation_note.pregnancy }}</p>
+        </div>
+        <div id="consultMemoText" class="consult-text">{{ consultation_note.memo_text }}</div>
+        <button id="copyConsultMemoBtn" type="button" class="consult-copy-btn">메모 복사</button>
+      </section>
+      {% endif %}
 
       {% if ingredients_data %}
       <section class="result-layout">
@@ -638,6 +728,7 @@
           <h2 class="panel-title">성분/제품 안내</h2>
           <div class="stack">
             {% for ing in ingredients_data %}
+            {% if ing.can_take %}
             <article class="card {% if ing.kr_durs or ing.fda_warning %}dur-emphasis {% endif %}" data-ingredient="{{ ing.name }}" data-can-take="{% if ing.can_take %}1{% else %}0{% endif %}">
               <header class="card-head">
                 <div class="name">
@@ -659,74 +750,15 @@
 
               <div class="body">
                 <div class="product-slot" data-role="product-slot">
-                  {% if ing.products %}
-                  <h3 class="section-title">추천 OTC 제품</h3>
-                  <ul class="products">
-                    {% for prod in ing.products|slice:":3" %}
-                    <li>
-                      <div class="product-top">
-                        {% if prod.amazon_image_url %}
-                        <img class="product-thumb" src="{{ prod.amazon_image_url }}" alt="{{ prod.brand_name|default:'OTC Product' }} image" loading="lazy" />
-                        {% endif %}
-                        <div class="product-main">
-                          {% if prod.amazon_url %}
-                          <strong><a class="product-title-link" href="{{ prod.amazon_url }}" target="_blank" rel="noopener noreferrer">{{ prod.brand_name|default:"Unknown Product" }}</a></strong>
-                          {% elif prod.dailymed_url %}
-                          <strong><a class="product-title-link" href="{{ prod.dailymed_url }}" target="_blank" rel="noopener noreferrer">{{ prod.brand_name|default:"Unknown Product" }}</a></strong>
-                          {% else %}
-                          <strong>{{ prod.brand_name|default:"Unknown Product" }}</strong>
-                          {% endif %}
-                          <p class="product-meta">제조사: {{ prod.manufacturer_name|default:"Unknown Manufacturer" }}</p>
-                          <p class="product-links">
-                            {% if prod.amazon_url %}
-                            <a href="{{ prod.amazon_url }}" target="_blank" rel="noopener noreferrer">아마존 상세</a>
-                            {% endif %}
-                            {% if prod.dailymed_url %}
-                            <a href="{{ prod.dailymed_url }}" target="_blank" rel="noopener noreferrer">DailyMed 정보</a>
-                            {% endif %}
-                          </p>
-                        </div>
-                      </div>
-                      {% if prod.amazon_rank_label %}
-                      <p class="amazon-rank">Amazon BSR: {{ prod.amazon_rank_label }}</p>
-                      {% endif %}
-                      <p>{{ prod.summary_kr|default:"효능 요약 정보를 불러오지 못했습니다. 복용 전 용법·용량과 주의사항을 확인하세요." }}</p>
-                      {% if prod.other_active_dur_notice %}
-                      <p class="product-dur-note">{{ prod.other_active_dur_notice }}</p>
-                      {% endif %}
-                      {% if prod.other_active_components %}
-                      <span class="hover-trigger">추가 주성분 보기</span>
-                      <div class="hover-box">
-                        <strong>출력 성분 외 주성분</strong>
-                        <ul>
-                          {% for comp in prod.other_active_components %}
-                          <li class="component-item">
-                            <div class="component-main">
-                              <strong class="component-name">{{ comp.name }}</strong>
-                              <span class="component-benefit">{{ comp.benefit }}</span>
-                              {% if comp.has_dur_risk %}
-                              <span class="comp-risk-chip">
-                                DUR 주의{% if comp.dur_risk_types %} - {{ comp.dur_risk_types|join:", " }}{% endif %}
-                              </span>
-                              {% endif %}
-                            </div>
-                            {% if comp.has_dur_risk and comp.dur_risk_summary %}
-                            <p class="component-risk-text">{{ comp.dur_risk_summary }}</p>
-                            {% endif %}
-                          </li>
-                          {% endfor %}
-                        </ul>
-                      </div>
-                      {% endif %}
-                    </li>
-                    {% endfor %}
-                  </ul>
+                  {% if ing.can_take %}
+                  <p>복용 가능 성분입니다. 제품 추천은 상단의 <strong>복용 가능 성분 제품 추천 보기</strong>에서 확인할 수 있습니다.</p>
                   {% else %}
-                  <p>미국 OTC 제품 조회 중...</p>
+                  <p>DUR 기준 복용 제한 성분으로 제품 추천 조회 대상에서 제외됩니다.</p>
                   {% endif %}
                 </div>
               </div>
             </article>
+            {% endif %}
             {% endfor %}
           </div>
 
@@ -734,34 +766,46 @@
 
         <aside class="side-area">
           <section class="side-panel">
-            <h2 class="panel-title">성분별 안내사항</h2>
-
+            <h2 class="panel-title">금기 사항별 안내</h2>
             <div class="caution-list">
-              {% for ing in ingredients_data %}
-              <article class="caution-card" data-ingredient="{{ ing.name }}">
-                <h3>{{ ing.name }}</h3>
-                {% if ing.kr_durs %}
-                <ul>
-                  {% for dur in ing.kr_durs %}
-                  <li><strong>{{ dur.type }}</strong> - {{ dur.warning }}</li>
-                  {% endfor %}
-                </ul>
-                {% else %}
-                <p>한국 DUR 기준 특이사항이 확인되지 않았습니다.</p>
-                {% endif %}
-                <div class="caution-fda" data-role="us-warning">
-                  {% if ing.fda_warning %}
-                  <p><strong>FDA</strong> - {{ ing.fda_warning }}</p>
-                  {% else %}
-                  <p><strong>FDA</strong> - 미국 DUR 정보 조회 중...</p>
-                  {% endif %}
-                </div>
+              <article class="caution-card">
+                <h3>병용금기</h3>
+                <p>현재 복용 중인 약 성분과 병용금기 성분이 일치하면 복용 위험으로 분류합니다.</p>
+                <p>일치 근거가 없으면 제품 제외가 아닌 주의 안내로 처리합니다.</p>
               </article>
-              {% endfor %}
-
-              {% if not dur_details %}
-              <p class="side-empty">확인된 안내사항이 없습니다.</p>
-              {% endif %}
+              <article class="caution-card">
+                <h3>임부금기</h3>
+                <p>임신/수유 상태에서 임부금기 성분이 확인되면 복용 위험으로 분류합니다.</p>
+                <p>해당 상태가 아니면 제품 제외가 아닌 주의 안내로 처리합니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>효능군중복</h3>
+                <p>같은 효능군 성분이 중복되면 부작용 위험이나 과다복용 위험이 커질 수 있다는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>용량주의</h3>
+                <p>권장 용량 범위를 지켜야 하며, 연령/체중/기저질환에 따라 용량 조정이 필요할 수 있다는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>투여기간주의</h3>
+                <p>권장 복용 기간을 초과하면 부작용 위험이 증가할 수 있어 단기 복용 원칙을 지켜야 한다는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>노인주의</h3>
+                <p>고령자에서 이상반응 위험이 커질 수 있어 복용 전 확인이 필요한 항목이라는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>특정연령대금기</h3>
+                <p>소아/청소년 등 특정 연령대에서는 복용이 금지되거나 제한될 수 있다는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>질환주의</h3>
+                <p>간/신장 질환 등 기저질환이 있는 경우 복용 전 전문가 확인이 필요하다는 안내입니다.</p>
+              </article>
+              <article class="caution-card">
+                <h3>일반주의</h3>
+                <p>금기까지는 아니지만 개인 상태에 따라 복용 시 주의가 필요할 수 있다는 안내입니다.</p>
+              </article>
             </div>
           </section>
         </aside>
@@ -1166,9 +1210,201 @@
         }
       }
 
+      function buildProductPrefetchKey(symptom, ingredients) {
+        const normalizedSymptom = String(symptom || "").trim().toUpperCase();
+        const normalizedIngredients = (ingredients || [])
+          .map((x) => String(x || "").trim().toUpperCase())
+          .filter(Boolean)
+          .join(",");
+        return `symptom-products-prefetch::${normalizedSymptom}::${normalizedIngredients}`;
+      }
+
+      const PRODUCTS_PREFETCH_NAV_WAIT_MS = 1800;
+      let productsPagePrefetchPromise = null;
+      let productsPagePrefetchDone = false;
+
+      async function prefetchProductsForProductsPage(options = {}) {
+        const dataNode = document.getElementById("ingredients-data-json");
+        if (!dataNode) return;
+
+        let ingredientsData = [];
+        try {
+          ingredientsData = JSON.parse(dataNode.textContent || "[]");
+        } catch (_) {
+          ingredientsData = [];
+        }
+
+        const toCanTakeFlag = (value) => {
+          if (typeof value === "boolean") return value;
+          const token = String(value || "").trim().toLowerCase();
+          return ["true", "1", "yes", "y", "on"].includes(token);
+        };
+
+        const safeIngredients = ingredientsData
+          .filter((ing) => ing && ing.name && toCanTakeFlag(ing.can_take))
+          .map((ing) => String(ing.name).trim().toUpperCase());
+        if (!safeIngredients.length) return;
+
+        const symptomTerm = "{{ symptom|escapejs }}";
+        const storageKey = buildProductPrefetchKey(symptomTerm, safeIngredients);
+        const now = Date.now();
+        const maxAgeMs = 5 * 60 * 1000;
+
+        try {
+          const cachedRaw = sessionStorage.getItem(storageKey);
+          if (cachedRaw) {
+            const cached = JSON.parse(cachedRaw);
+            const cachedAt = Number(cached?.cached_at || 0);
+            if (Array.isArray(cached?.items) && cachedAt > 0 && now - cachedAt <= maxAgeMs) {
+              sessionStorage.setItem("symptom-products-prefetch-latest-key", storageKey);
+              return;
+            }
+          }
+        } catch (_) {
+          // Ignore sessionStorage parse errors and continue prefetch.
+        }
+
+        const firstBatchSize = 2;
+        const nextBatchSize = 3;
+        const batches = [];
+        batches.push(safeIngredients.slice(0, firstBatchSize));
+        for (let i = firstBatchSize; i < safeIngredients.length; i += nextBatchSize) {
+          batches.push(safeIngredients.slice(i, i + nextBatchSize));
+        }
+        const maxBatches = Number.isInteger(options.maxBatches) && options.maxBatches > 0
+          ? Math.min(options.maxBatches, batches.length)
+          : batches.length;
+
+        const byIngredient = new Map();
+        for (let i = 0; i < maxBatches; i += 1) {
+          const batchIngredients = batches[i].filter(Boolean);
+          if (!batchIngredients.length) continue;
+
+          try {
+            const url = `/api/symptom-products/?ingredients=${encodeURIComponent(batchIngredients.join(","))}&symptom=${encodeURIComponent(symptomTerm)}`;
+            const res = await fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } });
+            const payload = await res.json();
+            if (!res.ok || payload.status !== "success") {
+              continue;
+            }
+
+            const items = Array.isArray(payload.items) ? payload.items : [];
+            items.forEach((item) => {
+              const ingredient = String(item?.ingredient || "").trim().toUpperCase();
+              if (!ingredient) return;
+              byIngredient.set(ingredient, item);
+            });
+          } catch (_) {
+            // Prefetch errors should not block normal navigation.
+          }
+        }
+
+        if (!byIngredient.size) return;
+
+        const normalizedItems = safeIngredients
+          .filter((ingredient) => byIngredient.has(ingredient))
+          .map((ingredient) => byIngredient.get(ingredient));
+        const fetchedIngredients = Array.from(byIngredient.keys());
+        const prefetchComplete = maxBatches >= batches.length;
+
+        try {
+          sessionStorage.setItem(
+            storageKey,
+            JSON.stringify({
+              schema_version: 2,
+              symptom: symptomTerm,
+              ingredients: safeIngredients,
+              items: normalizedItems,
+              fetched_ingredients: fetchedIngredients,
+              prefetch_complete: prefetchComplete,
+              cached_at: Date.now(),
+            })
+          );
+          sessionStorage.setItem("symptom-products-prefetch-latest-key", storageKey);
+        } catch (_) {
+          // Ignore quota/storage errors.
+        }
+      }
+
+      function startProductsPagePrefetch(options = {}) {
+        if (!productsPagePrefetchPromise) {
+          productsPagePrefetchPromise = prefetchProductsForProductsPage(options)
+            .catch(() => {})
+            .finally(() => {
+              productsPagePrefetchDone = true;
+            });
+        }
+        return productsPagePrefetchPromise;
+      }
+
+      function bindProductsPageLinkNavigation() {
+        const link = document.getElementById("productsPageLink");
+        if (!link || link.dataset.prefetchBound === "1") return;
+        link.dataset.prefetchBound = "1";
+
+        link.addEventListener("click", async (event) => {
+          if (productsPagePrefetchDone) return;
+
+          event.preventDefault();
+          const href = link.getAttribute("href") || "/smart-search-products/";
+          const originalText = link.textContent;
+          link.textContent = "제품 후보 준비 중...";
+          link.setAttribute("aria-busy", "true");
+
+          try {
+            await Promise.race([
+              startProductsPagePrefetch(),
+              new Promise((resolve) => setTimeout(resolve, PRODUCTS_PREFETCH_NAV_WAIT_MS)),
+            ]);
+          } finally {
+            link.textContent = originalText;
+            link.removeAttribute("aria-busy");
+            window.location.href = href;
+          }
+        });
+      }
+
+      function bindConsultMemoCopy() {
+        const copyBtn = document.getElementById("copyConsultMemoBtn");
+        const memoEl = document.getElementById("consultMemoText");
+        if (!copyBtn || !memoEl || copyBtn.dataset.copyBound === "1") return;
+        copyBtn.dataset.copyBound = "1";
+
+        copyBtn.addEventListener("click", async () => {
+          const text = (memoEl.textContent || "").trim();
+          if (!text) return;
+
+          const fallbackCopy = () => {
+            const temp = document.createElement("textarea");
+            temp.value = text;
+            document.body.appendChild(temp);
+            temp.select();
+            document.execCommand("copy");
+            document.body.removeChild(temp);
+          };
+
+          try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              await navigator.clipboard.writeText(text);
+            } else {
+              fallbackCopy();
+            }
+            const original = copyBtn.textContent;
+            copyBtn.textContent = "복사 완료";
+            setTimeout(() => {
+              copyBtn.textContent = original;
+            }, 1200);
+          } catch (_) {
+            fallbackCopy();
+          }
+        });
+      }
+
       document.addEventListener("DOMContentLoaded", () => {
         initIngredientCardInteractions();
-        initAsyncProductEnrichment();
+        bindProductsPageLinkNavigation();
+        bindConsultMemoCopy();
+        startProductsPagePrefetch();
       });
     </script>
   </body>


### PR DESCRIPTION
- 메인 페이지에 근처 약국 지도 UI 추가 (Leaflet + OSM)
- "내 위치 찾기" 버튼 추가 및 현재 위치 마커를 빨간색으로 표시
- 약국 핀 hover/popup에 이름/주소/전화/운영시간/영업상태 노출
- 지도 이동/줌 변경 시 현재 화면 영역 기준 약국 자동 재조회
- 약국 섹션 레이아웃을 지도 상단, 목록 하단으로 변경
- 백엔드 약국 응답에 운영시간 포함 (Google Details + OSM opening_hours)
- pet/vet(동물/수의) 관련 장소를 약국 결과에서 제외하는 필터 추가
- /api/pharmacies 좌표/파라미터 검증 강화 및 radius/limit 지원
- 의사/약사 상담용 메모를 영어로 생성하도록 변경
- 상담 메모의 증상/저장된 사용자 정보(복용약/알레르기/기저질환) 영어 변환 반영
